### PR TITLE
[BUGFIX] Add missing function name for contentPostProc-output hook

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,4 +7,4 @@ if (!defined('TYPO3_MODE')) {
 $TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkDataSubmission']['cps_stopdc'] = 'CPSIT\\CpsStopdc\\Hooks\\TypoScriptFrontendControllerHook';
 
 // Add canonical url to content
-$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output']['cps_stopdc'] = 'CPSIT\\CpsStopdc\\Hooks\\TypoScriptFrontendControllerHook';
+$TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-output']['cps_stopdc'] = 'CPSIT\\CpsStopdc\\Hooks\\TypoScriptFrontendControllerHook->contentPostProc_output';


### PR DESCRIPTION
Fixes: #8 